### PR TITLE
Revising terminology and history

### DIFF
--- a/explainer.html
+++ b/explainer.html
@@ -22,6 +22,11 @@ var respecConfig = {
     company: "Digital Bazaar",
     companyURL: "https://digitalbazaar.com/",
     w3cid: 41758
+  }, {
+    name: "Aidan Hogan",
+    url: "http://aidanhogan.com/",
+    company: "DCC, Universidad de Chile",
+    companyURL: "https://www.dcc.uchile.cl/"
   }],
 //    name: "Alan Karp",
 //    url: "https://alanhkarp.com/",

--- a/explainer.html
+++ b/explainer.html
@@ -165,7 +165,7 @@ labels used in the input RDF Dataset.
     <section>
       <h2>The General Problem Space</h2>
       <p>
-Though canonical labelling procedures for directed and undirected graphs have
+Though canonical labeling procedures for directed and undirected graphs have
 been studied for several decades, only in the past 10 years have two generalized
 approaches have been proposed for RDF Graphs and RDF Datasets:
       </p>

--- a/explainer.html
+++ b/explainer.html
@@ -99,7 +99,7 @@ refer to the formal RDF specification [[rdf11-concepts]].
       <dt id='dataset'>RDF Datasets</dt>
       <dd>
         <p>
-<span class='rdf'>R</span>, <span class='rdf'>S</span>,&nbsp; etc., each denote an <a
+<span class='rdf'>R</span>, <span class='rdf'>R'</span> and <span class='rdf'>S</span> each denote an <a
 href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a>
 [[rdf11-concepts]].
         </p>

--- a/explainer.html
+++ b/explainer.html
@@ -118,7 +118,7 @@ href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">named graphs</a>
 (under set equality).
         </p>
          <p>
-If <span class='rdf'>R</span> and <span class='rdf'>S</span> identical, we may equivalently say that they are the <em>same</em> RDF Dataset. 
+If <span class='rdf'>R</span> and <span class='rdf'>S</span> are identical, we may equivalently say that they are the <em>same</em> RDF Dataset. 
         </p>
       </dd>
 
@@ -142,7 +142,7 @@ it is possible to map the blank nodes of <span class='rdf'>R</span> to the blank
       <dd>
         <p>
 RDF Dataset Canonicalization is a function <span class='rdf'>C</span> 
-that maps an RDF Dataset to an RDF Dataset in manner that satisfies the following
+that maps an RDF Dataset to an RDF Dataset in a manner that satisfies the following
 two properties for all RDF Datasets <span class='rdf'>R</span> and <span class='rdf'>S</span>:
         </p>
         <ul>

--- a/explainer.html
+++ b/explainer.html
@@ -97,7 +97,7 @@ the problem space and associated use cases and requirements.
     <h2>Terminology</h2>
 
     <p>
-For a precise definition of the various terms and ceonepts, the reader should
+For a precise definition of the various terms and concepts, the reader should
 refer to the formal RDF specification [[rdf11-concepts]].
     </p>
 
@@ -155,7 +155,7 @@ two properties for all RDF Datasets <span class='rdf'>R</span> and <span class='
           <li> <span class='rdf'>R ≈ C(R)</span>; and</li> 
           <li> <span class='rdf'>C(R) = C(S)</span> if and only if <span class='rdf'>R ≈ S</span>.</li>
         </ul>
-        <p>
+        <p id="canonical_form">
 We may refer to <span class='rdf'>C(R)</span> as the <em>canonical form</em> of 
 <span class='rdf'>R</span> (under <span class='rdf'>C</span>).
         </p>

--- a/explainer.html
+++ b/explainer.html
@@ -167,7 +167,7 @@ labels used in the input RDF Dataset.
       <p>
 Though canonical labeling procedures for directed and undirected graphs have
 been studied for several decades, only in the past 10 years have two generalized
-approaches have been proposed for RDF Graphs and RDF Datasets:
+approaches been proposed for RDF Graphs and RDF Datasets:
       </p>
 
       <ol>

--- a/explainer.html
+++ b/explainer.html
@@ -131,9 +131,7 @@ If <span class='rdf'>R</span> and <span class='rdf'>S</span> are identical, we m
       <dt id='isomorphic'>Isomorphic RDF Datasets</dt>
       <dd>
         <p>
-<span class='rdf'>R ≈ S</span> denotes two <a
-href='https://www.w3.org/TR/rdf11-concepts/#section-dataset-isomorphism'><em>isomorphic</em></a>
-RDF Datasets.
+          <span class='rdf'>R ≈ S</span> denotes that <span class='rdf'>R</span> and <span class='rdf'>S</span> are <a href='https://www.w3.org/TR/rdf11-concepts/#section-dataset-isomorphism'><em>isomorphic</em></a> RDF Datasets. 
         </p>
         <p>
 Two isomorphic RDF Datasets are identical except for differences in how their individual blank nodes are labeled. 
@@ -157,7 +155,7 @@ two properties for all RDF Datasets <span class='rdf'>R</span> and <span class='
         </ul>
         <p id="canonical_form">
 We may refer to <span class='rdf'>C(R)</span> as the <em>canonical form</em> of 
-<span class='rdf'>R</span> (under <span class='rdf'>C</span>).
+<span class='rdf'>R</span> (under <span class='rdf'>C</span>&nbsp;).
         </p>
         <p>
 Such a canonicalization function can be implemented, in practice, as a

--- a/explainer.html
+++ b/explainer.html
@@ -130,8 +130,8 @@ href='https://www.w3.org/TR/rdf11-concepts/#section-dataset-isomorphism'><em>iso
 RDF Datasets.
         </p>
         <p>
-Two isomorphic RDF Datasets are identical up to the labeling of blank nodes. In particular,
-<span class='rdf'>R</span> is isomorphic with <span class='rdf'>S</span> if and only if
+Two isomorphic RDF Datasets are identical except for differences in how their individual blank nodes are labeled. 
+In particular, <span class='rdf'>R</span> is isomorphic with <span class='rdf'>S</span> if and only if
 it is possible to map the blank nodes of <span class='rdf'>R</span> to the blank nodes of 
 <span class='rdf'>S</span> in a one-to-one manner, generating an RDF dataset 
 <span class='rdf'>R'</span> such that <span class='rdf'>R' = S</span>.

--- a/explainer.html
+++ b/explainer.html
@@ -91,7 +91,7 @@ the problem space and associated use cases and requirements.
     <h2>Terminology</h2>
 
     <p>
-For a precise definition for the various terms and notions, the reader should
+For a precise definition of the various terms and ceonepts, the reader should
 refer to the formal RDF specification [[rdf11-concepts]].
     </p>
 
@@ -108,14 +108,17 @@ href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a>
       <dt id='identical'>Identical RDF Datasets</dt>
       <dd>
         <p>
-          <span class='rdf'>R = S</span> denotes that <span class='rdf'>R</span> and <span class='rdf'>S</span> are <em>identical</em> RDF Datasets. 
-          We can also say that <span class='rdf'>R</span> and <span class='rdf'>S</span> are the same RDF Dataset.
+<span class='rdf'>R = S</span> denotes that <span class='rdf'>R</span> and <span class='rdf'>S</span> are <em>identical</em> RDF Datasets. 
         </p>
         <p>
 Two RDF Datasets are identical if and only if they have the same <a
 href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">default graph</a>
-and the same set of <a
-href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">named graphs</a>.
+(under set equality) and the same set of <a
+href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">named graphs</a>
+(under set equality).
+        </p>
+         <p>
+If <span class='rdf'>R</span> and <span class='rdf'>S</span> identical, we may equivalently say that they are the <em>same</em> RDF Dataset. 
         </p>
       </dd>
 

--- a/explainer.html
+++ b/explainer.html
@@ -92,33 +92,30 @@ the problem space and associated use cases and requirements.
 
     <p>
 For a precise definition for the various terms and notions, the reader should
-refer to the formal RDF specification [[rdf11-concepts]]. Note also that the
-term “Linked Data” is used as a synonym to “RDF Datasets”.
+refer to the formal RDF specification [[rdf11-concepts]].
     </p>
 
     <dl>
       <dt id='dataset'>RDF Datasets</dt>
       <dd>
         <p>
-<span class='rdf'>R</span>, <span class='rdf'>S</span>,&nbsp; etc., denote an <a
+<span class='rdf'>R</span>, <span class='rdf'>S</span>,&nbsp; etc., each denote an <a
 href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a>
 [[rdf11-concepts]].
-        </p>
-        <p>
-The term “named graphs” is also used in literature or in applications.
         </p>
       </dd>
 
       <dt id='identical'>Identical RDF Datasets</dt>
       <dd>
         <p>
-<span class='rdf'>R = S</span> denotes two <em>identical</em> RDF Datasets.
+          <span class='rdf'>R = S</span> denotes that <span class='rdf'>R</span> and <span class='rdf'>S</span> are <em>identical</em> RDF Datasets. 
+          We can also say that <span class='rdf'>R</span> and <span class='rdf'>S</span> are the same RDF Dataset.
         </p>
         <p>
-Identical RDF Datasets consists of the same <a
-href="https://www.w3.org/TR/rdf11-concepts/#section-rdf-graph">RDF Graphs</a>
-(where “the same” means they are the same set of triples) with the same <a
-href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">Graph Names</a>.
+Two RDF Datasets are identical if and only if they have the same <a
+href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">default graph</a>
+and the same set of <a
+href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">named graphs</a>.
         </p>
       </dd>
 
@@ -130,60 +127,43 @@ href='https://www.w3.org/TR/rdf11-concepts/#section-dataset-isomorphism'><em>iso
 RDF Datasets.
         </p>
         <p>
-The structure of two isomorphic Datasets are identical: URIs and literals are
-all character-wise identical, and it is possible to relabel the blank nodes of
-<span class='rdf'>R</span> to the blank nodes of <span class='rdf'>S</span>,
-generating an RDF dataset <span class='rdf'>R'</span> such that 
-<span class='rdf'>R' = S</span>.
+Two isomorphic RDF Datasets are identical up to the labeling of blank nodes. In particular,
+<span class='rdf'>R</span> is isomorphic with <span class='rdf'>S</span> if and only if
+it is possible to map the blank nodes of <span class='rdf'>R</span> to the blank nodes of 
+<span class='rdf'>S</span> in a one-to-one manner, generating an RDF dataset 
+<span class='rdf'>R'</span> such that <span class='rdf'>R' = S</span>.
         </p>
       </dd>
-
-      <dt id="canonical_form">Canonical Form</dt>
-      <dd>
-        <p>
-For an RDF Dataset <span class='rdf'>R</span>, a <em>canonical form</em> of
-<span class='rdf'>R</span> is a dataset <span class='rdf'>R<sub>C</sub></span>
-such that <span class='rdf'>R ≈ R<sub>C</sub></span> and 
-<span class='rdf'>R<sub>C</sub> = S<sub>C</sub></span> if and only if
-<span class='rdf'>R ≈ S</span>.
-        </p>
-      </dd>
-
-      <dt id='canonicalization'>Canonicalization</dt>
-      <dd>
-        <p>
-Canonicalization is a function <span class='rdf'>C</span> on RDF Datasets such
-that <span class='rdf'>C(R)</span> is a Canonical Form for <span
-class='rdf'>R</span>.
-        </p>
-        <p>
-Definition of a canonicalization function means, in practice, to define a
-deterministic re-labeling procedure of all blank nodes of an RDF Dataset without
-changing the topology of the graph, and whose result is not dependent on the
-particular set of blank node labels used in the Dataset.
-        </p>
-      </dd>
-
+      
       <dt id='canonicalization'>RDF Dataset Canonicalization</dt>
       <dd>
         <p>
-A <a href="https://en.wikipedia.org/wiki/Graph_canonization">
-graph canonicalization function</a> <span
-class='rdf'>C</span> defined on RDF Datasets which has the additional property
-that for any RDF Datasets <span class='rdf'>R</span> and <span
-class='rdf'>S</span>, the relation <span class='rdf'>R&nbsp;≈&nbsp;S</span>
-implies <span class='rdf'>C(R)&nbsp;=&nbsp;C(S)</span>.
+RDF Dataset Canonicalization is a function <span class='rdf'>C</span> 
+that maps an RDF Dataset to an RDF Dataset and satisfies two properties:
         </p>
-
+        <ul>
+          <li> <span class='rdf'>R ≈ C(R)</span>; and</li> 
+          <li> <span class='rdf'>C(R) = C(S)</span> if and only if <span class='rdf'>R ≈ S</span>.</li>
+        </ul>
+        <p>
+We may refer to <span class='rdf'>C(R)</span> as the <em>canonical form</em> of 
+<span class='rdf'>R</span> (under <span class='rdf'>C</span>).
+        </p>
+        <p>
+Such a canonicalization function can be implemented, in practice, as a
+procedure that deterministically re-labels all blank nodes of an RDF Dataset
+in a one-to-one manner, without depending on the particular set of blank node 
+labels used in the input RDF Dataset.
+        </p>
       </dd>
     </dl>
 
     <section>
       <h2>The General Problem Space</h2>
       <p>
-Defining a generalized canonicalization function was an unsolved mathematical
-problem until the last decade. Over the past 10 years, at least two generalized
-approaches have been proposed:
+Though canonical labelling procedures for directed and undirected graphs have
+been studied for several decades, only in the past 10 years have two generalized
+approaches have been proposed for RDF Graphs and RDF Datasets:
       </p>
 
       <ol>
@@ -202,7 +182,7 @@ package</a> used in several JSON-LD Signature suites.
 
       <p>
 The introduction of <a
-href="http://aidanhogan.com/docs/rdf-canonicalisation.pdf">Adrian Hogan’s
+href="http://aidanhogan.com/docs/rdf-canonicalisation.pdf">Aidan Hogan’s
 paper</a>&nbsp;[[aidan-2017]] also contains a more thorough description of the
 underlying mathematical challenges.
       </p>

--- a/explainer.html
+++ b/explainer.html
@@ -142,7 +142,8 @@ it is possible to map the blank nodes of <span class='rdf'>R</span> to the blank
       <dd>
         <p>
 RDF Dataset Canonicalization is a function <span class='rdf'>C</span> 
-that maps an RDF Dataset to an RDF Dataset and satisfies two properties:
+that maps an RDF Dataset to an RDF Dataset in manner that satisfies the following
+two properties for all RDF Datasets <span class='rdf'>R</span> and <span class='rdf'>S</span>:
         </p>
         <ul>
           <li> <span class='rdf'>R ≈ C(R)</span>; and</li> 

--- a/explainer.html
+++ b/explainer.html
@@ -26,7 +26,8 @@ var respecConfig = {
     name: "Aidan Hogan",
     url: "http://aidanhogan.com/",
     company: "DCC, Universidad de Chile",
-    companyURL: "https://www.dcc.uchile.cl/"
+    companyURL: "https://www.dcc.uchile.cl/",
+    orcid: "0000-0001-9482-1982"
   }],
 //    name: "Alan Karp",
 //    url: "https://alanhkarp.com/",

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@ RDF Dataset Canonicalization (RDC)
           <dd>
             <p>
 This specification defines an algorithm to produce a <a
-href="./explainer.html#canonical_form">canonical form</a> of an arbitrary RDF
+href="./explainer.html#canonicalization">canonicalization function</a> of an arbitrary RDF
 Dataset.
             </p>
 


### PR DESCRIPTION
Aiming to provide more precise but still readable definitions in the terminology.

Revising a couple of phrases in history to mention the long line of work on canonical labelling for undirected and directed graphs.

See
- [Preview the document](https://raw.githack.com/w3c/lds-wg-charter/aidhog-revisions/explainer.html)
- [Diff to previous version](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Flds-wg-charter%2Fexplainer.html&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Flds-wg-charter%2Faidhog-revisions%2Fexplainer.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/pull/22.html" title="Last updated on Apr 1, 2021, 5:03 AM UTC (1eceff9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/22/5120aba...1eceff9.html" title="Last updated on Apr 1, 2021, 5:03 AM UTC (1eceff9)">Diff</a>