### PR TITLE
Adding Skolem IRI use-case

### DIFF
--- a/explainer.html
+++ b/explainer.html
@@ -302,6 +302,22 @@ not depend on a single point of failure, such as a local government office.
 <br>Requirement: A way of encoding and verifying a digital proof that is
 not a digital signature on an RDF Dataset.
       </dd>
+      <dt>
+Generating canonical Skolem IRIs for blank nodes
+      </dt>
+      <dd>
+<a href="https://www.w3.org/TR/rdf11-concepts/#section-skolemization">Skolem IRIs</a> 
+have been proposed in RDF 1.1 as a way to replace blank nodes with IRIs in application 
+scenarios where it is preferable to avoid the use of blank nodes. Rather than 
+using an ad hoc scheme to generate Skolem IRIs to replace blank nodes, an 
+alternative is to generate Skolem IRIs in a deterministic manner, such that 
+compliant implementations will generate the same IRIs to replace the same blank
+nodes in isomorphic copies of an RDF graph or dataset. Such a procedure will
+produce a canonical version of a Skolemized RDF graph that can then be used
+in the context of several of the use-cases mentioned previously.
+<br>Requirement: An RDF Dataset Canonicalization algorithm that produces canonical
+ labels for blank nodes and a convention to compute Skolem IRIs from these labels.
+      </dd>
     </dl>
   </section>
 


### PR DESCRIPTION
Adding short description of the Skolem IRI use-case. It is perhaps more of a "meta" use-case in that it would define a canonical form for Skolemized graphs that can be used in the context of the other use-cases.

Fix #27