### PR TITLE
Changed the LDH deliverable to RDH

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
                         </p>
                     </dd>
 
-                    <dt id="hash" class="spec">Linked Data Hash (LDH)</dt>
+                    <dt id="hash" class="spec">RDF Dataset Hash (RDH)</dt>
                     <dd>
                         <p>
                             This specification details the processing steps of a hash function for an arbitrary RDF Dataset. These step include (1) the generation of a <a href="./explainer.html#canonical_form">canonical form</a> using the algorithm specified in the “RDF Dataset Canonicalization” deliverable, (2) sorting the <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> serialization of the canonical form generated in the previous step, and (3) application of a cryptographic hash function on the sorted <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> representation. 
@@ -355,13 +355,13 @@
                         WG-START +3 months: FPWD for RDC
                     </li>
                     <li>
-                        WG-START +6 months: FPWD for LDH, LDI, and LDSV
+                        WG-START +6 months: FPWD for RDH, LDI, and LDSV
                     </li>
                     <li>
                         WG-START +15 months: CR for RDC
                     </li>
                     <li>
-                        WG-START +18 months: CR for LDH, LDI, and LDSV
+                        WG-START +18 months: CR for RDH, LDI, and LDSV
                     </li>
                     <li>
                         WG-START +24 months: REC for all standards-track documents


### PR DESCRIPTION
Renaming the "Linked Data Hash" deliverable to "RDF Dataset Hash".

Fix #63


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/pull/64.html" title="Last updated on May 3, 2021, 12:34 PM UTC (9af756e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/64/7ace91f...9af756e.html" title="Last updated on May 3, 2021, 12:34 PM UTC (9af756e)">Diff</a>