### PR TITLE
Editorial swig discussion - maximal change

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         </div>
 
         <p class="mission">
-            The <strong>mission</strong> of the <a href="https://www.w3.org/2021/lds-wg/" class=todo>Linked Data Signatures Working Group</a> is to define a standard for uniquely identifying and securing <a href='https://www.w3.org/standards/semanticweb/data'>Linked Data</a> used in use cases such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>. The work will include defining <a href="explainer.html#canonicalization"> RDF Dataset Canonicalization</a> algorithms as well as algorithms and vocabularies for encoding digital proofs, such as <a href='https://en.wikipedia.org/wiki/Digital_signature'>digital signatures</a>, and with that secure information expressed in serializations such as <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>, <a href="https://www.w3.org/TR/trig/">TriG</a>, and <a href="https://www.w3.org/TR/n-quads/">N-Quads</a>.
+            The <strong>mission</strong> of the <a href="https://www.w3.org/2021/lds-wg/" class=todo>Linked Data Signatures Working Group</a> is to define a standard for uniquely identifying and securing <a href='https://www.w3.org/standards/semanticweb/data'>Linked Data</a> used in use cases such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>. The work will include defining <a href="explainer.html#canonicalization">RDF Dataset Canonicalization</a> algorithms as well as algorithms and vocabularies for encoding digital proofs, such as <a href='https://en.wikipedia.org/wiki/Digital_signature'>digital signatures</a>, and with that secure information expressed in serializations such as <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>, <a href="https://www.w3.org/TR/trig/">TriG</a>, and <a href="https://www.w3.org/TR/n-quads/">N-Quads</a>.
         </p>
 
         <section id="details">
@@ -211,11 +211,15 @@
             <h2>Scope</h2>
 
             <p>
+                A terminological note: in what follows in this charter, and in the terminology to be used by the Working Group, the term “Linked Data” is used as a synonym to “RDF”.   
+            </p>
+
+            <p>
                 The deployment of <a href='https://www.w3.org/standards/semanticweb/data'>Linked Data</a> is <a href="http://webdatacommons.org/structureddata/#toc3"> increasing at a rapid pace</a>. There are a variety of established use cases, such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>, the publication of biological and pharmaceutical data, consumption of mission critical RDF vocabularies, and others, that depend on the ability to verify the authenticity and integrity of the data being consumed (see the <a href="explainer.html#usage">use cases</a> for more examples). In order to achieve these use cases, a standard way to process <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Datasets</a> is needed. More specifically, the ability to <a href="https://en.wikipedia.org/wiki/Graph_canonization"> canonicalize</a>, <a href="https://en.wikipedia.org/wiki/Cryptographic_hash_function"> cryptographically hash</a>, <a href="https://en.wikipedia.org/wiki/Digital_signature">digitally sign</a>, and encode the result of that process on an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a> is required.
             </p>
 
             <p>
-                The scope of this Working Group is to define standards to <a href="./explainer.html#canonicalization">canonicalize</a>, <a href="./explainer.html#hash"> cryptographically hash</a>, and <a href='./explainer.html#sign'>digitally sign</a> an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a>. This includes the definition of a standard <a href='./explainer.html#canonicalization'>canonicalization algorithm</a>, a generic algorithm for generating and verifying a digital proof using existing cryptographic primitives, an RDF vocabulary for expressing the results of digital proof generation algorithm, and a way of representing and referencing specific existing cryptographic proof algorithms and parameters in a format that can be referred to from an RDF Dataset. The Working Group will also provide standard ways to represent this vocabulary in various RDF serialization formats, such as by providing <a href='https://www.w3.org/TR/json-ld11/#the-context'>JSON-LD contexts</a> for JSON-LD serializations. (See the separate <a href="./explainer.html">explainer document</a> for more detailed technical backgrounds and for the terminology used in this context.)
+                The scope of this Working Group is to define standards to <a href="./explainer.html#canonicalization">canonicalize</a>, <a href="./explainer.html#hash">cryptographically hash</a>, and <a href='./explainer.html#sign'>digitally sign</a> an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a>. This includes the definition of a standard <a href='./explainer.html#canonicalization'>canonicalization algorithm</a>, a generic algorithm for generating and verifying a digital proof using existing cryptographic primitives, an RDF vocabulary for expressing the results of digital proof generation algorithm, and a way of representing and referencing specific existing cryptographic proof algorithms and parameters in a format that can be referred to from an RDF Dataset. The Working Group will also provide standard ways to represent this vocabulary in various RDF serialization formats, such as by providing <a href='https://www.w3.org/TR/json-ld11/#the-context'>JSON-LD contexts</a> for JSON-LD serializations. (See the separate <a href="./explainer.html">explainer document</a> for more detailed technical backgrounds and for the terminology used in this context.)
             </p>
 
             <section id="section-out-of-scope">
@@ -226,8 +230,7 @@
 
                 <ul>
                     <li>
-                        Definition of new cryptographic signature or encryption algorithms such as RSA, ECDSA, EdDSA, and AES. This Working Group will only define usage of, and suitable terms to <em>identify</em>, such algorithms. The Working Group will
-                        also define terms for the input and output parameters to those algorithms that the community has developed, or will develop in future.
+                        Definition of new cryptographic signature or encryption algorithms such as RSA, ECDSA, EdDSA, and AES. This Working Group will only define usage of, and suitable terms to <em>identify</em>, such algorithms. The Working Group will also define terms for the input and output parameters to those algorithms that the community has developed, or will develop in future.
                     </li>
                 </ul>
             </section>
@@ -268,7 +271,7 @@
                         </p>
                         <ol>
                             <li>
-                                <a href="https://lists.w3.org/Archives/Public/public-credentials/2021Mar/att-0220/RDFDatasetCanonicalization-2020-10-09.pdf"> RDF Dataset Canonicalization</a>, Rachel Arnold, Dave Longley, W3C Credentials Community Group, 2020.
+                                <a href="https://lists.w3.org/Archives/Public/public-credentials/2021Mar/att-0220/RDFDatasetCanonicalization-2020-10-09.pdf">RDF Dataset Canonicalization</a>, Rachel Arnold, Dave Longley, W3C Credentials Community Group, 2020.
                             </li>
                             <li>
                                 <a href="http://aidanhogan.com/docs/rdf-canonicalisation.pdf">Canonical Forms for Isomorphic and Equivalent RDF Graphs: Algorithms for Leaning and Labelling Blank Nodes</a>, Aidan Hogan, ACM Trans. Web, vol. 11, no. 4, p. 22:1-22:62, 2017.

--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
                         </p>
                     </dd>
 
-                    <dt id="hash" class="spec">Linked Data Hash (LDH)</dt>
+                    <dt id="hash" class="spec">RDF Dataset Hash (RDH)</dt>
                     <dd>
                         <p>
                             This specification details the processing steps of a hash function for an arbitrary RDF Dataset. These step include (1) the generation of a <a href="./explainer.html#canonical_form">canonical form</a> using the algorithm specified in the “RDF Dataset Canonicalization” deliverable, (2) sorting the <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> serialization of the canonical form generated in the previous step, and (3) application of a cryptographic hash function on the sorted <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> representation. 
@@ -355,13 +355,13 @@
                         WG-START +3 months: FPWD for RDC
                     </li>
                     <li>
-                        WG-START +6 months: FPWD for LDH, LDI, and LDSV
+                        WG-START +6 months: FPWD for RDH, LDI, and LDSV
                     </li>
                     <li>
                         WG-START +15 months: CR for RDC
                     </li>
                     <li>
-                        WG-START +18 months: CR for LDH, LDI, and LDSV
+                        WG-START +18 months: CR for RDH, LDI, and LDSV
                     </li>
                     <li>
                         WG-START +24 months: REC for all standards-track documents

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
 
-    <title>Linked Data Signatures Working Group Charter</title>
+    <title>RDF Signatures Working Group Charter</title>
 
     <link rel="stylesheet" type="text/css" media="screen" href="https://www.w3.org/2005/10/w3cdoc.css">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -130,7 +130,7 @@
 
     <main>
         <h1 id="title">
-            <em class=todo>Proposed</em> Linked Data Signatures Working Group Charter
+            <em class=todo>Proposed</em> RDF Signatures Working Group Charter
         </h1>
         <!-- delete PROPOSED after AC review completed -->
 
@@ -151,7 +151,7 @@
         </div>
 
         <p class="mission">
-            The <strong>mission</strong> of the <a href="https://www.w3.org/2021/lds-wg/" class=todo>Linked Data Signatures Working Group</a> is to define a standard for uniquely identifying and securing <a href='https://www.w3.org/standards/semanticweb/data'>Linked Data</a> used in use cases such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>. The work will include defining <a href="explainer.html#canonicalization">RDF Dataset Canonicalization</a> algorithms as well as algorithms and vocabularies for encoding digital proofs, such as <a href='https://en.wikipedia.org/wiki/Digital_signature'>digital signatures</a>, and with that secure information expressed in serializations such as <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>, <a href="https://www.w3.org/TR/trig/">TriG</a>, and <a href="https://www.w3.org/TR/n-quads/">N-Quads</a>.
+            The <strong>mission</strong> of the <a href="https://www.w3.org/2021/lds-wg/" class=todo>RDF Signatures Working Group</a> is to define a standard for uniquely identifying and securing <a href='https://www.w3.org/standards/semanticweb/data'>RDF</a> used in use cases such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>. The work will include defining <a href="explainer.html#canonicalization">RDF Dataset Canonicalization</a> algorithms as well as algorithms and vocabularies for encoding digital proofs, such as <a href='https://en.wikipedia.org/wiki/Digital_signature'>digital signatures</a>, and with that secure information expressed in serializations such as <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>, <a href="https://www.w3.org/TR/trig/">TriG</a>, and <a href="https://www.w3.org/TR/n-quads/">N-Quads</a>.
         </p>
 
         <section id="details">
@@ -209,13 +209,8 @@
 
         <section id="scope" class="scope">
             <h2>Scope</h2>
-
             <p>
-                A terminological note: in what follows in this charter, and in the terminology to be used by the Working Group, the term “Linked Data” is used as a synonym to “RDF”.   
-            </p>
-
-            <p>
-                The deployment of <a href='https://www.w3.org/standards/semanticweb/data'>Linked Data</a> is <a href="http://webdatacommons.org/structureddata/#toc3"> increasing at a rapid pace</a>. There are a variety of established use cases, such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>, the publication of biological and pharmaceutical data, consumption of mission critical RDF vocabularies, and others, that depend on the ability to verify the authenticity and integrity of the data being consumed (see the <a href="explainer.html#usage">use cases</a> for more examples). In order to achieve these use cases, a standard way to process <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Datasets</a> is needed. More specifically, the ability to <a href="https://en.wikipedia.org/wiki/Graph_canonization"> canonicalize</a>, <a href="https://en.wikipedia.org/wiki/Cryptographic_hash_function"> cryptographically hash</a>, <a href="https://en.wikipedia.org/wiki/Digital_signature">digitally sign</a>, and encode the result of that process on an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a> is required.
+                The deployment of <a href='https://www.w3.org/standards/semanticweb/data'>RDF Data</a> is <a href="http://webdatacommons.org/structureddata/#toc3"> increasing at a rapid pace</a>. There are a variety of established use cases, such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>, the publication of biological and pharmaceutical data, consumption of mission critical RDF vocabularies, and others, that depend on the ability to verify the authenticity and integrity of the data being consumed (see the <a href="explainer.html#usage">use cases</a> for more examples). In order to achieve these use cases, a standard way to process <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Datasets</a> is needed. More specifically, the ability to <a href="https://en.wikipedia.org/wiki/Graph_canonization">canonicalize</a>, <a href="https://en.wikipedia.org/wiki/Cryptographic_hash_function">cryptographically hash</a>, <a href="https://en.wikipedia.org/wiki/Digital_signature">digitally sign</a>, and encode the result of that process on an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a> is required.
             </p>
 
             <p>
@@ -296,10 +291,10 @@
                         </p>
                     </dd>
 
-                    <dt id="integrity" class="spec">Linked Data Integrity (LDI)</dt>
+                    <dt id="integrity" class="spec">RDF Data Integrity (RDI)</dt>
                     <dd>
                         <p>
-                            This specification defines a generic framework for expressing proofs of integrity of Linked Datasets via, for example, digital signatures, proofs of work, or proofs of existence. Beyond the generic (normative) framework, this deliverable also provides a normative definition for Linked Data Signatures, as well as a means to express these proofs in an RDF Dataset in a way that enables a 3rd party to verify the integrity of the data.
+                            This specification defines a generic framework for expressing proofs of integrity of RDF Datasets via, for example, digital signatures, proofs of work, or proofs of existence. Beyond the generic (normative) framework, this deliverable also provides a normative definition for RDF Dataset Signatures, as well as a means to express these proofs in an RDF Dataset in a way that enables a 3rd party to verify the integrity of the data.
                         </p>
                         <p class="draft-status">
                             <b>Draft State</b> to be adopted from: <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
@@ -309,10 +304,10 @@
                         </p>
                     </dd>
 
-                    <dt id="vocabulary" class="spec">Linked Data Security Vocabulary (LDSV)</dt>
+                    <dt id="vocabulary" class="spec">RDF Security Vocabulary (RSV)</dt>
                     <dd>
                         <p>
-                            This specification defines a formal RDF Vocabulary for the terms defined in the Linked Data Integrity deliverable. The specification may also define one or more <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD Context</a> documents to be used by a JSON-LD serialization.
+                            This specification defines a formal RDF Vocabulary for the terms defined in the RDF Data Integrity deliverable. The specification may also define one or more <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD Context</a> documents to be used by a JSON-LD serialization.
                         </p>
 
                         <p class="draft-status">
@@ -333,10 +328,10 @@
                 <ul>
                     <li>
                         <p>
-                            A Linked Data Security Registry, containing Linked Data related cryptographic terms, including, but not limited to, the terms defined in the Linked Data Security Vocabulary (LDSV), as well as terms for the definition of other Linked Data Integrity related proof methods.
+                            An RDF Security Registry, containing RDF related cryptographic terms, including, but not limited to, the terms defined in the RDF Security Vocabulary (RSV), as well as terms for the definition of other RDF Data Integrity related proof methods.
                         </p>    
                         <p>
-                            If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the Linked Data Security Vocabulary Recommendation with an additional <a href="https://www.w3.org/Consortium/Process/Drafts/#registry-section">Registry Section</a> incorporating the terms planned in this deliverable.
+                            If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the RDF Security Vocabulary Recommendation with an additional <a href="https://www.w3.org/Consortium/Process/Drafts/#registry-section">Registry Section</a> incorporating the terms planned in this deliverable.
                         </p>    
                     </li>
                     <li>
@@ -358,13 +353,13 @@
                         WG-START +3 months: FPWD for RDC
                     </li>
                     <li>
-                        WG-START +6 months: FPWD for RDH, LDI, and LDSV
+                        WG-START +6 months: FPWD for RDH, RDI, and RSV
                     </li>
                     <li>
                         WG-START +15 months: CR for RDC
                     </li>
                     <li>
-                        WG-START +18 months: CR for RDH, LDI, and LDSV
+                        WG-START +18 months: CR for RDH, RDI, and RSV
                     </li>
                     <li>
                         WG-START +24 months: REC for all standards-track documents
@@ -435,11 +430,11 @@
                 <dl>
                     <dt><a href="https://datatracker.ietf.org/rg/cfrg/about/"> Internet Engineering Task Force Crypto Forum Research Group </a> </dt>
                     <dd>
-                        To perform broad horizontal reviews on the output of the Working Group and to ensure that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Linked Data Security ecosystem.
+                        To perform broad horizontal reviews on the output of the Working Group and to ensure that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the RDF Security ecosystem.
                     </dd>
                     <dt><a href="https://www.nist.gov/"> National Institute of Standards and Technology, U.S. Department of Commerce </a></dt>
                     <dd>
-                        To coordinate in ensuring that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Linked Data Security ecosystem.
+                        To coordinate in ensuring that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the RDF Security ecosystem.
                     </dd>
                     <dt><a href="https://www.hyperledger.org/use/aries"> Hyperledger Aries</a></dt>
                     <dd>
@@ -478,9 +473,9 @@
                 Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however.
             </p>
             <p>
-                Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="" class=todo>Linked Data Signatures Working Group home page.</a> </p>
+                Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="" class=todo>RDF Signatures Working Group home page.</a> </p>
             <p>
-                Most Linked Data Signatures Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+                Most RDF Signatures Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
             </p>
             <p>
                 This group primarily conducts its technical work on <a href="[link to Github repo]"><i class='todo'>GitHub issues</i></a>. The public is invited to review, discuss and contribute to this work.


### PR DESCRIPTION
See the [discussion thread in the semantic web mailing list](https://lists.w3.org/Archives/Public/semantic-web/2021May/0001.html) for the background. 

This is a proposed maximal change: removal of the term "Linked Data", using the term "RDF" everywhere.

Note that this incorporates the proposal of PR #64