### PR TITLE
Improved version of the charter and the explainer

### DIFF
--- a/explainer.html
+++ b/explainer.html
@@ -94,7 +94,7 @@ var respecConfig = {
   <section id='canonicalize'>
     <h2>Terminology</h2>
 
-    <section id="ld-vs-rdf">
+    <section id="ld-and-rdf">
       <h2>Linked Data and RDF relationships</h2>
 
       <p>

--- a/explainer.html
+++ b/explainer.html
@@ -94,6 +94,17 @@ var respecConfig = {
   <section id='canonicalize'>
     <h2>Terminology</h2>
 
+    <section id="ld-vs-rdf">
+      <h2>Linked Data and RDF relationships</h2>
+
+      <p>
+        The term “Linked Data” was originally <a href="https://www.w3.org/DesignIssues/LinkedData.html">defined in 2006</a>. However, this was never a formal definition and the term’s use has evolved over time. These days it can encompass resolvable URI schemes other than HTTP (notably <a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers</a>) and may be used informally as a general term for any set of facts linked over the Web. Different communities may use these terms differently, although the underlying data model and semantics are close, if not identical. The work proposed by the charter necessarily focuses specifically on the underlying RDF technology. <em>For this reason, in the <a href="index.html">proposed charter</a> and in the terminology to be used by the Working Group, the terms “Linked Data” and “RDF” are used largely as a synonyms.</em>
+      </p>
+  </section>
+  <section>
+    <h2>Canonicalization terminology</h2>
+
+
     <p>
       For a precise definition of the various terms and concepts, the reader should refer to the formal RDF specification [[rdf11-concepts]].
     </p>
@@ -184,9 +195,7 @@ var respecConfig = {
       </p>
     </section>
     
-    <section id="noProblem"><h2>Where there is no problem</h2>
-      <p>When a digitally signed file is transferred from one system to another and used <em>as is</em>, there is no need for any processing other than checking the digital signature. This is as true for RDF as any other data format and existing signature and other cryptographic proof methods may be used. However, RDF has many serializations for datasets, notably <a href="https://www.w3.org/TR/trig/">TriG</a>, <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>, <a href="https://www.w3.org/TR/n-quads/">N-quads</a> and, informally, <a href="https://digitalbazaar.github.io/cbor-ld-spec/">CBOR-LD</a>. The same RDF dataset can be transferred in any of those serializations and is typically processed by querying the underlying RDF graph, not by querying the original serialized data. So, yes, you <em>can</em> process JSON-LD as JSON (that's a key design feature) but you can equally extract the triples and work with that, or transform it into CBOR-LD for use in a constrained environment like a QR code etc. It's this range of serializations and usage scenarios that creates the need to be able to sign the underlying dataset, irrespective of its serialization.</p>
-    </section>
+  </section>
   </section>
 
   <section id="goals">
@@ -214,6 +223,10 @@ var respecConfig = {
     <p>
       The main challenge for the Working Group is to provide a standard for the <a href="#canonicalization">RDF Dataset Canonicalization function</a>. That paves the way for uniquely identifying RDF Datasets, as well as methods to digitally sign RDF Datasets.
     </p>
+
+    <div id="noProblem" class=note>
+      <p>When a digitally signed file is transferred from one system to another and used <em>as is</em>, there is no need for any processing other than checking the digital signature. This is as true for RDF as any other data format and existing signature and other cryptographic proof methods may be used. However, RDF has many serializations for datasets, notably <a href="https://www.w3.org/TR/trig/">TriG</a>, <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>, <a href="https://www.w3.org/TR/n-quads/">N-quads</a> and, informally, <a href="https://digitalbazaar.github.io/cbor-ld-spec/">CBOR-LD</a>. The same RDF dataset can be transferred in any of those serializations and is typically processed by querying the underlying RDF graph, not by querying the original serialized data. So, yes, you <em>can</em> process JSON-LD as JSON (that's a key design feature) but you can equally extract the triples and work with that, or transform it into CBOR-LD for use in a constrained environment like a QR code etc. It's this range of serializations and usage scenarios that creates the need to be able to sign the underlying dataset, irrespective of its serialization.</p>
+    </div>
   </section>
 
   <section id=usage>

--- a/index.html
+++ b/index.html
@@ -222,9 +222,12 @@
 
         <section id="scope" class="scope">
             <h2>Scope</h2>
+            <p>
+                (For the usage of the terms “RDF” and “Linked Data", see the <a href="./explainer.html#ld-vs-rdf">terminological note</a> in the explainer document.)                
+            </p>
 
             <p>
-                The deployment of <a href='https://www.w3.org/standards/semanticweb/data'>Linked Data</a> is <a href="http://webdatacommons.org/structureddata/#toc3"> increasing at a rapid pace</a>. There are a variety of established use cases, such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>, the publication of biological and pharmaceutical data, consumption of mission critical RDF vocabularies, and others, that depend on the ability to verify the authenticity and integrity of the data being consumed (see the <a href="explainer.html#usage">use cases</a> for more examples). In order to achieve these use cases, a standard way to process <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Datasets</a> is needed. More specifically, the ability to <a href="https://en.wikipedia.org/wiki/Graph_canonization"> canonicalize</a>, <a href="https://en.wikipedia.org/wiki/Cryptographic_hash_function"> cryptographically hash</a>, <a href="https://en.wikipedia.org/wiki/Digital_signature">digitally sign</a>, and encode the result of that process on an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Dataset</a> is required.
+                There are a variety of use cases in the area of Linked Data, such as <a href="https://www.w3.org/TR/vc-data-model">Verifiable Credentials</a>, the publication of biological and pharmaceutical data, or consumption of mission critical RDF vocabularies that depend on the ability to verify the authenticity and integrity of the data being consumed. (See the <a href="explainer.html#usage">use cases</a> for more examples.) In order to achieve these use cases, a standard way to process <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF Datasets</a> is needed. 
             </p>
 
             <p>
@@ -239,8 +242,10 @@
 
                 <ul>
                     <li>
-                        Definition of new cryptographic signature or encryption algorithms such as RSA, ECDSA, EdDSA, and AES. This Working Group will only define usage of, and suitable terms to <em>identify</em>, such algorithms. The Working Group will
-                        also define terms for the input and output parameters to those algorithms that the community has developed, or will develop in future.
+                        Definition of new cryptographic signature or encryption algorithms such as RSA, ECDSA, EdDSA, and AES. This Working Group will only define usage of, and suitable terms to <em>identify</em>, such algorithms.
+                    </li>
+                    <li>
+                        Authenticity and trust issues of Web (Data) content that go beyond the exchange and the integration of simple factual data expressed in RDF. 
                     </li>
                 </ul>
             </section>
@@ -352,6 +357,11 @@
                         </p>    
                     </li>
                     <li>
+                        <p>
+                            Note on additional Linked Data Integrity techniques that are not necessarily relying, or only partially, on the specifications developed by this Working Group.
+                        </p>
+                    </li>
+                    <li>
                         <p>Test suite and implementation report for the specification.</p>
                     </li>
                     <li>
@@ -445,9 +455,13 @@
             <section>
                 <h3 id="external-coordination">External Organizations</h3>
                 <dl>
-                    <dt><a href="https://datatracker.ietf.org/rg/cfrg/about/"> Internet Engineering Task Force Crypto Forum Research Group </a> </dt>
+                    <dt><a href="https://datatracker.ietf.org/rg/cfrg/about/">Internet Engineering Task Force Crypto Forum Research Group </a> </dt>
                     <dd>
                         To perform broad horizontal reviews on the output of the Working Group and to ensure that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Linked Data Security ecosystem.
+                    </dd>
+                    <dt><a href="https://datatracker.ietf.org/group/artart/about/">Internet Engineering Task Force ART Area Review Team</a></dt>
+                    <dd>
+                        To coordinate on the work on the work of <a href="https://datatracker.ietf.org/doc/draft-jordan-jws-ct/">JWS Clear Text JSON Signature Option</a> to ensure that no obstacle should be created for further possible harmonization.
                     </dd>
                     <dt><a href="https://www.nist.gov/"> National Institute of Standards and Technology, U.S. Department of Commerce </a></dt>
                     <dd>

--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
         <section id="scope" class="scope">
             <h2>Scope</h2>
             <p>
-                (For the usage of the terms “RDF” and “Linked Data", see the <a href="./explainer.html#ld-vs-rdf">terminological note</a> in the explainer document.)                
+                (For the usage of the terms “RDF” and “Linked Data", see the <a href="./explainer.html#ld-and-rdf">terminological note</a> in the explainer document.)                
             </p>
 
             <p>


### PR DESCRIPTION
Version after the discussion on the SWIG mailing list and related issues.

- the relationship between LD vs. RDF is detailed in the explainer
- additional non-normative note on additional proof approaches 
- removal of some too 'marketing' type statements
- addition of out-of-scope entries on issues related to LD when going beyond simple RDF datasets


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/pull/72.html" title="Last updated on May 10, 2021, 1:48 PM UTC (624d1ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/72/9ca4ab2...624d1ff.html" title="Last updated on May 10, 2021, 1:48 PM UTC (624d1ff)">Diff</a>