### PR TITLE
Exchange "draft state" against "reference"

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,8 @@
                 <a href="https://www.w3.org/2021/lds-wg/PublStatus" class=todo>group publication status page</a>.
             </p>
             <p>
-                <i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.
+                <i><b>Reference</b></i> is to a (draft) specification used as a primary input to the work.
+                <i><b>Expected completion</b></i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.
             </p>
             <p>
                 Note that the titles of the documents are tentative and not final. The Working Group may also decide to either split some of those documents or, conversely, merge some of them. See also a <a href="./explainer.html#separation">note in the explainer</a> for some more backgrounds on the structure of deliverables.
@@ -278,7 +279,7 @@
                         </p>
 
                         <p class="draft-status">
-                            <b>Draft State</b> to be adopted from: <a href="https://json-ld.github.io/rdf-dataset-canonicalization/spec/index.html">RDF Dataset Canonicalization</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2019.
+                            <b>Reference</b>: <a href="https://json-ld.github.io/rdf-dataset-canonicalization/spec/index.html">RDF Dataset Canonicalization</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2019.
                         </p>
 
                         <p class="milestone">
@@ -306,7 +307,7 @@
                         </p>
 
                         <p class="draft-status">
-                            <b>Draft State</b> to be adopted from: <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
+                            <b>Reference</b>: <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
                         </p>
                         <p class="milestone">
                             <b>Expected completion:</b> WG-START + 24 months.
@@ -319,7 +320,7 @@
                             This specification defines a generic framework for expressing proofs of integrity of Linked Datasets via, for example, digital signatures, proofs of work, or proofs of existence. Beyond the generic (normative) framework, this deliverable also provides a normative definition for Linked Data Signatures, as well as a means to express these proofs in an RDF Dataset in a way that enables a 3rd party to verify the integrity of the data.
                         </p>
                         <p class="draft-status">
-                            <b>Draft State</b> to be adopted from: <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
+                            <b>Reference</b>: <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
                         </p>
                         <p class="milestone">
                             <b>Expected completion:</b> WG-START + 24 months.
@@ -333,7 +334,7 @@
                         </p>
 
                         <p class="draft-status">
-                            <b>Draft State</b> to be adopted from: <a href="https://w3c-ccg.github.io/security-vocab/">The Security Vocabulary</a>, ed. Manu Sporny, Orie Steele, Tobias Looker, W3C Draft Community Group Report, 2020.
+                            <b>Reference</b>: <a href="https://w3c-ccg.github.io/security-vocab/">The Security Vocabulary</a>, ed. Manu Sporny, Orie Steele, Tobias Looker, W3C Draft Community Group Report, 2020.
                         </p>
                         <p class="milestone">
                             <b>Expected completion:</b> WG-START + 24 months.


### PR DESCRIPTION
This is to avoid the false impressions given by the earlier formulation (inherited from the charter template).

See also, e.g., https://lists.w3.org/Archives/Public/semantic-web/2021May/0111.html

Cc @danbri @pfps


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/pull/81.html" title="Last updated on May 13, 2021, 10:07 AM UTC (cfd156c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/81/4a88284...cfd156c.html" title="Last updated on May 13, 2021, 10:07 AM UTC (cfd156c)">Diff</a>