### PR TITLE
Update index.html to leave options open for RDH

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
                     <dt id="hash" class="spec">RDF Dataset Hash (RDH)</dt>
                     <dd>
                         <p>
-                            This specification details the processing steps of a hash function for an arbitrary RDF Dataset. These step include (1) the generation of a <a href="./explainer.html#canonical_form">canonical form</a> using the algorithm specified in the “RDF Dataset Canonicalization” deliverable, (2) sorting the <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> serialization of the canonical form generated in the previous step, and (3) application of a cryptographic hash function on the sorted <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> representation. 
+                            This specification details the processing steps of a hash function for an arbitrary RDF Dataset. These step include (1) the generation of a <a href="./explainer.html#canonical_form">canonical form</a> for the RDF Dataset using the algorithm specified in the “RDF Dataset Canonicalization” deliverable, (2) application of a hash function over the canonical form of the RDF Dataset. 
                         </p>
 
                         <p class="draft-status">


### PR DESCRIPTION
Rather than "baking in" the sorting of N-Quads for RDH into the charter (which is a viable but not ideal solution), making the language more general to allow for RDH implementations that hash individual triples/quads and then combine the hashes in a commutative and associative (i.e., order-independent) way, which should be a lot easier in practice, particularly for larger datasets.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/pull/93.html" title="Last updated on Dec 16, 2021, 5:46 PM UTC (4c38444)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lds-wg-charter/93/f976d48...4c38444.html" title="Last updated on Dec 16, 2021, 5:46 PM UTC (4c38444)">Diff</a>